### PR TITLE
PR: Ordered parent child index

### DIFF
--- a/app/controllers/director_films_controller.rb
+++ b/app/controllers/director_films_controller.rb
@@ -1,7 +1,12 @@
 class DirectorFilmsController < ApplicationController
   def index
-    @director = Director.find(params[:director_id])
-    @films = @director.films
+    if params[:sort]
+      @director = Director.find(params[:director_id])
+      @films = @director.films.order(name: params[:sort])
+    else
+      @director = Director.find(params[:director_id])
+      @films = @director.films
+    end
   end
 
   def new

--- a/app/controllers/director_films_controller.rb
+++ b/app/controllers/director_films_controller.rb
@@ -3,4 +3,23 @@ class DirectorFilmsController < ApplicationController
     @director = Director.find(params[:director_id])
     @films = @director.films
   end
+
+  def new
+    @director = Director.find(params[:director_id])
+    @films = @director.films
+  end
+  
+  def create
+    @director = Director.find(params[:director_id])
+    @films = @director.films
+    @films.create!(director_film_params)
+    
+    redirect_to "/directors/#{@director.id}/films"
+  end
+
+  private
+
+  def director_film_params
+    params.permit(:name, :rt_rank, :nominated)
+  end
 end

--- a/app/controllers/director_films_controller.rb
+++ b/app/controllers/director_films_controller.rb
@@ -6,7 +6,6 @@ class DirectorFilmsController < ApplicationController
 
   def new
     @director = Director.find(params[:director_id])
-    @films = @director.films
   end
   
   def create

--- a/app/controllers/directors_controller.rb
+++ b/app/controllers/directors_controller.rb
@@ -19,6 +19,16 @@ class DirectorsController < ApplicationController
     redirect_to '/directors'
   end
 
+  def edit
+    @director = Director.find(params[:id])
+  end
+  
+  def update
+    @director = Director.find(params[:id])
+    @director.update(director_params)
+    redirect_to "/directors/#{@director.id}"
+  end
+
   private
 
   def director_params

--- a/app/controllers/directors_controller.rb
+++ b/app/controllers/directors_controller.rb
@@ -6,4 +6,22 @@ class DirectorsController < ApplicationController
   def show
     @director = Director.find(params[:id])
   end
+
+  def new
+    @director = Director.new
+  end
+
+  def create
+    # @director = Director.new(director_params)
+    # @director.save
+    @director = Director.create!(director_params)
+
+    redirect_to '/directors'
+  end
+
+  private
+
+  def director_params
+    params.permit(:name, :imdb_rank, :tv_credit)
+  end
 end

--- a/app/controllers/films_controller.rb
+++ b/app/controllers/films_controller.rb
@@ -6,4 +6,20 @@ class FilmsController < ApplicationController
   def show
     @film = Film.find(params[:id])
   end
+
+  def edit
+    @film = Film.find(params[:id])
+  end
+
+  def update
+    @film = Film.find(params[:id])
+    @film.update(films_params)
+    redirect_to "/films/#{@film.id}"
+  end
+
+  private
+
+  def films_params
+    params.permit(:name, :rt_rank, :nominated)
+  end
 end

--- a/app/models/film.rb
+++ b/app/models/film.rb
@@ -3,4 +3,8 @@ class Film < ApplicationRecord
 
   validates_presence_of :name, :rt_rank
   validates :nominated, inclusion: [true, false]
+
+  def self.nominated_only
+    where(nominated: true)
+  end
 end

--- a/app/views/director_films/index.html.erb
+++ b/app/views/director_films/index.html.erb
@@ -4,6 +4,8 @@
 </nav>
 
 <h1><%= @director.name %></h1>
+<h2><a href="/directors/<%= @director.id %>/films/new">Create Film</a></h2>
+<br>
 <% @films.each do |film| %>
   <h3><%= film.name %></h3>
   <ul>

--- a/app/views/director_films/index.html.erb
+++ b/app/views/director_films/index.html.erb
@@ -6,6 +6,7 @@
 <h1><%= @director.name %></h1>
 <h2><a href="/directors/<%= @director.id %>/films/new">Create Film</a></h2>
 <br>
+<%= link_to 'Sort alphabetical', "/directors/#{@director.id}/films?sort=asc" %>
 <% @films.each do |film| %>
   <h3><%= film.name %></h3>
   <ul>

--- a/app/views/director_films/new.html.erb
+++ b/app/views/director_films/new.html.erb
@@ -1,0 +1,13 @@
+<h1>New Director Film</h1>
+<%= form_with url: "/directors/#{@director.id}/films", method: :post, local: true do |f| %>
+    <%= f.label :name, 'Film Name:' %>
+    <%= f.text_field :name %>
+    <br>
+    <%= f.label :rt_rank, 'Rotten Tomatoes Rank:' %>
+    <%= f.number_field :rt_rank, in: 0..100, step: 1 %>
+    <br>
+    <%= f.label :nominated, 'Award Nominated Film:' %>
+    <%= f.select :nominated, ['Yes', 'No'], selected: 'No' %>
+    <br>
+    <%= f.submit 'Create Film' %>
+<% end %>

--- a/app/views/directors/edit.html.erb
+++ b/app/views/directors/edit.html.erb
@@ -1,0 +1,13 @@
+<h1>Edit Director</h1>
+<%= form_with url: "/directors/#{@director.id}", method: :patch, local: true do |f| %>
+    <%= f.label :name, 'Director Full Name:' %>
+    <%= f.text_field :name %>
+    <br>
+    <%= f.label :imdb_rank, 'IMDB Ranking:' %>
+    <%= f.number_field :imdb_rank, in: 0..100, step: 1 %>
+    <br>
+    <%= f.label :tv_credit, 'TV Credit:' %>
+    <%= f.select :tv_credit, ['Yes', 'No'], selected: 'No' %>
+    <br>
+    <%= f.submit 'Update Director' %>
+<% end %>

--- a/app/views/directors/index.html.erb
+++ b/app/views/directors/index.html.erb
@@ -4,6 +4,8 @@
 </nav>
 
 <h1>Directors Index</h1>
+<h2><a href="/directors/new">Add New Director</a></h2>
+<br>
 <% @directors.desc_order_by_created.each do |director| %>
   <p><%= director.name %> - Created at: <%= director.created_at %></p>
 <% end %>

--- a/app/views/directors/new.html.erb
+++ b/app/views/directors/new.html.erb
@@ -1,0 +1,13 @@
+<h1>New Director</h1>
+<%= form_with url: '/directors', method: :post, local: true do |f| %>
+    <%= f.label :name, 'Director Full Name:' %>
+    <%= f.text_field :name %>
+    <br>
+    <%= f.label :imdb_rank, 'IMDB Ranking:' %>
+    <%= f.number_field :imdb_rank, in: 0..100, step: 1 %>
+    <br>
+    <%= f.label :tv_credit, 'TV Credit:' %>
+    <%= f.select :tv_credit, ['Yes', 'No'], selected: 'No' %>
+    <br>
+    <%= f.submit 'Create Director' %>
+<% end %>

--- a/app/views/directors/show.html.erb
+++ b/app/views/directors/show.html.erb
@@ -10,3 +10,4 @@
   <li>IMDB Ranking: <%= @director.imdb_rank %></li>
   <li>TV Credit: <%= @director.tv_credit %></li>
 </ul>
+<a href="/directors/<%= @director.id %>/edit">Update Director</a>

--- a/app/views/films/edit.html.erb
+++ b/app/views/films/edit.html.erb
@@ -1,0 +1,13 @@
+<h1>Edit Film</h1>
+<%= form_with url: "/films/#{@film.id}", method: :patch, local: true do |f| %>
+    <%= f.label :name, 'Film Name:' %>
+    <%= f.text_field :name %>
+    <br>
+    <%= f.label :rt_rank, 'Rotten Tomatoes Rank:' %>
+    <%= f.number_field :rt_rank, in: 0..100, step: 1 %>
+    <br>
+    <%= f.label :nominated, 'Award Nominated Film:' %>
+    <%= f.select :nominated, ['Yes', 'No'], selected: 'No' %>
+    <br>
+    <%= f.submit 'Update Film' %>
+<% end %>

--- a/app/views/films/index.html.erb
+++ b/app/views/films/index.html.erb
@@ -4,7 +4,7 @@
 </nav>
 
 <h1>Films Index</h1>
-<% @films.each do |film| %>
+<% @films.nominated_only.each do |film| %>
   <h3><%= film.name %></h3>
   <ul>
     <li>Rotten Tomatoes Ranking: <%= film.rt_rank %></li>

--- a/app/views/films/show.html.erb
+++ b/app/views/films/show.html.erb
@@ -4,7 +4,8 @@
 </nav>
 
 <h1><%= @film.name %></h1>
+<h2><a href="/films/<%= @film.id %>/edit">Update Film</a></h2>
 <ul>
   <li>Rotten Tomatoes Rank: <%= @film.rt_rank %></li>
-  <li>Award Nomintated Film: <%= @film.nominated %></li>
+  <li>Award Nominated Film: <%= @film.nominated %></li>
 <ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,8 +3,10 @@ Rails.application.routes.draw do
   get '/directors', to: 'directors#index'
   get '/directors/new', to: 'directors#new'
   get '/directors/:id', to: 'directors#show'
+  get '/directors/:id/edit', to: 'directors#edit'
   get '/directors/:director_id/films', to: 'director_films#index'
   post '/directors', to: 'directors#create'
+  patch '/directors/:id', to: 'directors#update'
 
   get '/films', to: 'films#index'
   get '/films/:id', to: 'films#show'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,10 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   get '/directors', to: 'directors#index'
+  get '/directors/new', to: 'directors#new'
   get '/directors/:id', to: 'directors#show'
   get '/directors/:director_id/films', to: 'director_films#index'
+  post '/directors', to: 'directors#create'
 
   get '/films', to: 'films#index'
   get '/films/:id', to: 'films#show'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,8 @@ Rails.application.routes.draw do
 
   get '/films', to: 'films#index'
   get '/films/:id', to: 'films#show'
+  get '/films/:id/edit', to: 'films#edit'
+  patch '/films/:id', to: 'films#update'
 
   get '/galleries', to: 'galleries#index'
   get '/galleries/:id', to: 'galleries#show'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,9 @@ Rails.application.routes.draw do
   get '/directors/:id', to: 'directors#show'
   get '/directors/:id/edit', to: 'directors#edit'
   get '/directors/:director_id/films', to: 'director_films#index'
+  get '/directors/:director_id/films/new', to: 'director_films#new'
   post '/directors', to: 'directors#create'
+  post '/directors/:director_id/films', to: 'director_films#create'
   patch '/directors/:id', to: 'directors#update'
 
   get '/films', to: 'films#index'

--- a/spec/features/directors/edit_spec.rb
+++ b/spec/features/directors/edit_spec.rb
@@ -25,7 +25,6 @@ RSpec.describe '/directors/:id/edit', type: :feature do
         select 'Yes', from: :tv_credit
         click_on 'Update Director'
 
-        save_and_open_page
         expect(page).to have_current_path("/directors/#{director_1.id}")
         expect(page).to have_content('Dennis Villeneuve')
         expect(page).to have_content('30')

--- a/spec/features/directors/edit_spec.rb
+++ b/spec/features/directors/edit_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe '/directors/:id/edit', type: :feature do
+  let!(:director_1) { Director.create!(name: 'Wes Anderson', imdb_rank: 20, tv_credit: false) }
+
+  describe 'as a user' do
+    describe 'when I visit the page at /directors/:id/edit' do
+      it 'has input forms for updating the director' do
+        visit "/directors/#{director_1.id}"
+        click_on 'Update Director'
+
+        expect(page).to have_field('Director Full Name:')
+        expect(page).to have_field('IMDB Ranking:')
+        expect(page).to have_field('TV Credit:')
+      end
+    end
+
+    describe 'when they fill in the input forms' do
+      it 'updates the Director with new info and returns to /directors/:id' do
+        visit "/directors/#{director_1.id}"
+        click_on 'Update Director'
+
+        fill_in :name, with: 'Dennis Villeneuve'
+        fill_in :imdb_rank, with: 30
+        select 'Yes', from: :tv_credit
+        click_on 'Update Director'
+
+        save_and_open_page
+        expect(page).to have_current_path("/directors/#{director_1.id}")
+        expect(page).to have_content('Dennis Villeneuve')
+        expect(page).to have_content('30')
+        expect(page).to have_content('true')
+      end
+    end
+  end
+end

--- a/spec/features/directors/films/index_spec.rb
+++ b/spec/features/directors/films/index_spec.rb
@@ -63,6 +63,12 @@ RSpec.describe '/director_films/index.html.erb', type: :feature do
         
         expect(page).to have_link("Create Film", :href=>"/directors/#{director_1.id}/films/new")
       end
+
+      it 'displays a link to sort alphabetically' do
+        visit "/directors/#{director_1.id}/films"
+
+        expect(page).to have_link("Sort alphabetical", :href=>"/directors/#{director_1.id}/films?sort=asc")
+      end
     end
 
     describe 'can click links' do
@@ -99,6 +105,22 @@ RSpec.describe '/director_films/index.html.erb', type: :feature do
         click_link 'Create Film'
         
         expect(page).to have_current_path("/directors/#{director_1.id}/films/new")
+      end
+
+      it 'can reload the page with films sorted alphabetically' do
+        film_4 = director_1.films.create!(name: 'Darjeeling Limited', rt_rank: 47, nominated: true)
+
+        visit "/directors/#{director_1.id}/films"
+        expect(film_1.name).to appear_before(film_2.name)
+        expect(film_1.name).to appear_before(film_4.name)
+        expect(film_2.name).to appear_before(film_4.name)
+
+        click_link 'Sort alphabetical'
+        
+        expect(page).to have_current_path("/directors/#{director_1.id}/films?sort=asc")
+        expect(film_1.name).to appear_before(film_4.name)
+        expect(film_1.name).to appear_before(film_2.name)
+        expect(film_4.name).to appear_before(film_2.name)
       end
     end
   end

--- a/spec/features/directors/films/index_spec.rb
+++ b/spec/features/directors/films/index_spec.rb
@@ -57,6 +57,12 @@ RSpec.describe '/director_films/index.html.erb', type: :feature do
         visit "/directors/#{director_3.id}/films"
         expect(page).to have_link("Directors Index", :href=>"/directors")
       end
+
+      it 'displays a link called create film' do
+        visit "/directors/#{director_1.id}/films"
+        
+        expect(page).to have_link("Create Film", :href=>"/directors/#{director_1.id}/films/new")
+      end
     end
 
     describe 'can click links' do
@@ -86,6 +92,13 @@ RSpec.describe '/director_films/index.html.erb', type: :feature do
         visit "/directors/#{director_3.id}/films"
         click_link 'Directors Index'
         expect(page).to have_current_path("/directors")
+      end
+
+      it 'redirect the user to create new film' do
+        visit "/directors/#{director_1.id}/films"
+        click_link 'Create Film'
+        
+        expect(page).to have_current_path("/directors/#{director_1.id}/films/new")
       end
     end
   end

--- a/spec/features/directors/films/new_spec.rb
+++ b/spec/features/directors/films/new_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe '/directors/:director_id/films/new', type: :feature do
+  let!(:director_1) { Director.create!(name: 'Wes Anderson', imdb_rank: 20, tv_credit: false) }
+
+  describe 'as a user' do
+    describe 'when I visit the page at /directors/:director_id/films/new' do
+      it 'has input forms for creating a new director film' do
+        visit "/directors/#{director_1.id}/films"
+        click_on 'Create Film'
+
+        expect(page).to have_field('Film Name:')
+        expect(page).to have_field('Rotten Tomatoes Rank:')
+        expect(page).to have_field('Award Nominated Film:')
+      end
+
+      it 'creates a new director film and returns to /directors/:director_id/films' do
+        visit "/directors/#{director_1.id}/films"
+        click_on 'Create Film'
+
+        fill_in :name, with: 'The Royal Tenenbaums'
+        fill_in :rt_rank, with: 23
+        select 'Yes', from: :nominated
+        click_on 'Create Film'
+
+        expect(page).to have_current_path("/directors/#{director_1.id}/films")
+        expect(page).to have_content('The Royal Tenenbaums')
+        expect(page).to have_content('Rotten Tomatoes Rank: 23')
+        expect(page).to have_content('Award Nominated Film: true')
+      end
+    end
+  end
+end

--- a/spec/features/directors/index_spec.rb
+++ b/spec/features/directors/index_spec.rb
@@ -52,6 +52,12 @@ RSpec.describe '/director/index.html.erb', type: :feature do
 
         expect(page).to have_link("Directors Index", :href=>"/directors")
       end
+      
+      it 'displays a link called New Director' do
+        visit '/directors'
+
+        expect(page).to have_link("New Director", :href=>"/directors/new")
+      end
     end
 
     describe 'can click links' do
@@ -67,6 +73,13 @@ RSpec.describe '/director/index.html.erb', type: :feature do
         click_link 'Directors Index'
         
         expect(page).to have_current_path("/directors")
+      end
+
+      it 'redirect the user to the new director form' do
+        visit '/directors'
+        click_link 'New Director'
+        
+        expect(page).to have_current_path("/directors/new")
       end
     end
   end

--- a/spec/features/directors/new_spec.rb
+++ b/spec/features/directors/new_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper' 
+
+RSpec.describe '/directors/new.html.erb' do
+  describe 'as a user' do
+    describe 'when I visit the page at /directors/new' do
+      it 'has input forms for creating a new director' do
+        visit '/directors'
+        click_on 'Add New Director'
+
+        expect(page).to have_field('Director Full Name:')
+        expect(page).to have_field('IMDB Ranking:')
+        expect(page).to have_field('TV Credit:')
+      end
+    end
+
+    describe 'when they fill in a input forms' do
+      it 'creates a new article' do
+        visit '/directors'
+        click_on 'Add New Director'
+
+        fill_in :name, with: 'Taika Waititi'
+        fill_in :imdb_rank, with: '13'
+        select 'Yes', from: :tv_credit
+        click_on 'Create Director'
+
+        expect(page).to have_content('Taika Waititi')
+      end
+    end
+  end
+end

--- a/spec/features/directors/new_spec.rb
+++ b/spec/features/directors/new_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe '/directors/new.html.erb' do
     end
 
     describe 'when they fill in a input forms' do
-      it 'creates a new article' do
+      it 'creates a new Director and returns to /directors' do
         visit '/directors'
         click_on 'Add New Director'
 
@@ -23,6 +23,7 @@ RSpec.describe '/directors/new.html.erb' do
         select 'Yes', from: :tv_credit
         click_on 'Create Director'
 
+        expect(page).to have_current_path('/directors')
         expect(page).to have_content('Taika Waititi')
       end
     end

--- a/spec/features/directors/show_spec.rb
+++ b/spec/features/directors/show_spec.rb
@@ -74,10 +74,21 @@ RSpec.describe '/directors/show.html.erb', type: :feature do
         visit "/directors/#{director_3.id}"
         expect(page).to have_link("#{director_3.name}'s Films Index", :href=>"/directors/#{director_3.id}/films")
       end
+
+      it 'displays a link called Update Director' do
+        visit "/directors/#{director_1.id}"
+        expect(page).to have_link("Update Director", :href=>"/directors/#{director_1.id}/edit")
+
+        visit "/directors/#{director_2.id}"
+        expect(page).to have_link("Update Director", :href=>"/directors/#{director_2.id}/edit")
+
+        visit "/directors/#{director_3.id}"
+        expect(page).to have_link("Update Director", :href=>"/directors/#{director_3.id}/edit")
+      end
     end
 
     describe 'can click links' do
-      it 'redirect the user to the Films index' do
+      it 'redirects the user to the Films index' do
         visit "/directors/#{director_1.id}"
         click_link 'Films Index'
         expect(page).to have_current_path("/films")
@@ -91,7 +102,7 @@ RSpec.describe '/directors/show.html.erb', type: :feature do
         expect(page).to have_current_path("/films")
       end
 
-      it 'redirect the user to the Directors index' do
+      it 'redirects the user to the Directors index' do
         visit "/directors/#{director_1.id}"
         click_link 'Directors Index'
         expect(page).to have_current_path("/directors")
@@ -105,7 +116,7 @@ RSpec.describe '/directors/show.html.erb', type: :feature do
         expect(page).to have_current_path("/directors")
       end
 
-      it 'redirect the user to the Directors name films index' do
+      it 'redirects the user to the Directors name films index' do
         visit "/directors/#{director_1.id}"
         click_link "#{director_1.name}'s Films Index"
         expect(page).to have_current_path("/directors/#{director_1.id}/films")
@@ -117,6 +128,13 @@ RSpec.describe '/directors/show.html.erb', type: :feature do
         visit "/directors/#{director_3.id}"
         click_link "#{director_3.name}'s Films Index"
         expect(page).to have_current_path("/directors/#{director_3.id}/films")
+      end
+
+      it 'redirects the user to the Directors edit page' do
+        visit "/directors/#{director_1.id}"
+        click_link "Update Director"
+
+        expect(page).to have_current_path("/directors/#{director_1.id}/edit")
       end
     end
   end

--- a/spec/features/directors/show_spec.rb
+++ b/spec/features/directors/show_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe '/directors/show.html.erb', type: :feature do
 
   describe 'as a user' do
     describe 'when I visit the director id' do
-      it 'should visit the page at /director/:id' do
+      it 'should visit the page at /directors/:id' do
         visit "/directors/#{director_1.id}"
 
         expect(page).to have_current_path("/directors/#{director_1.id}")

--- a/spec/features/films/edit_spec.rb
+++ b/spec/features/films/edit_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe '/films/:id/edit', type: :feature do
+  let!(:director_1) { Director.create!(name: 'Wes Anderson', imdb_rank: 20, tv_credit: false) }
+  let!(:director_2) { Director.create!(name: 'Steven Spielberg', imdb_rank: 1, tv_credit: true) }
+  let!(:director_3) { Director.create!(name: 'George Lucas', imdb_rank: 25, tv_credit: true) }
+
+  let!(:film_1) { director_1.films.create!(name: 'Bottle Rocket', rt_rank: 85, nominated: false) }
+  let!(:film_2) { director_1.films.create!(name: 'Life Aquatic', rt_rank: 56, nominated: false) }
+  let!(:film_3) { director_3.films.create!(name: 'Star Wars: A New Hope', rt_rank: 92, nominated: true) }
+
+  describe 'as a user' do
+    describe 'when I visit the page at /films/:id/edit' do
+      it 'has input forms for updating the Film' do
+        visit "/films/#{film_1.id}"
+        click_on 'Update Film'
+
+        expect(page).to have_field('Film Name:')
+        expect(page).to have_field('Rotten Tomatoes Rank:')
+        expect(page).to have_field('Award Nominated Film:')
+      end
+    end
+
+    describe 'when they fill in the input forms' do
+      it 'updates the Film with new info and returns them to /films/:id' do
+        visit "/films/#{film_1.id}"
+        click_on 'Update Film'
+
+        fill_in :name, with: 'Moonrise Kingdom'
+        fill_in :rt_rank, with: 44
+        select 'Yes', from: :nominated
+        click_on 'Update Film'
+
+        expect(page).to have_current_path("/films/#{film_1.id}")
+        expect(page).to have_content('Moonrise Kingdom')
+        expect(page).to have_content('Rotten Tomatoes Rank: 44')
+        expect(page).to have_content('Award Nominated Film: true')
+      end
+    end
+  end
+end

--- a/spec/features/films/index_spec.rb
+++ b/spec/features/films/index_spec.rb
@@ -8,37 +8,35 @@ RSpec.describe '/films/index.html.erb', type: :feature do
   let!(:film_1) { director_1.films.create!(name: 'Bottle Rocket', rt_rank: 85, nominated: false) }
   let!(:film_2) { director_1.films.create!(name: 'Life Aquatic', rt_rank: 56, nominated: false) }
   let!(:film_3) { director_3.films.create!(name: 'Star Wars: A New Hope', rt_rank: 92, nominated: true) }
+  let!(:film_4) { director_3.films.create!(name: 'Star Wars: Empire Strikes Back', rt_rank: 1, nominated: true) }
   
   describe 'as a user' do
     describe 'when I visit the films index' do
       it 'should visit the page at /films/' do
         visit '/films'
-
+        
         expect(page).to have_current_path('/films')
       end
 
-      it 'displays all the films names' do
+      it 'displays films names with nominated status' do
         visit '/films'
 
-        expect(page).to have_content(film_1.name)
-        expect(page).to have_content(film_2.name)
         expect(page).to have_content(film_3.name)
+        expect(page).to have_content(film_4.name)
       end
       
-      it 'displays all the films RT rank' do
+      it 'displays films RT rank with nominated status' do
         visit '/films'
         
-        expect(page).to have_content(film_1.rt_rank)
-        expect(page).to have_content(film_2.rt_rank)
         expect(page).to have_content(film_3.rt_rank)
+        expect(page).to have_content(film_4.rt_rank)
       end
 
-      it 'displays all the films nominated status' do
+      it 'displays films with nominated status' do
         visit '/films'
         
-        expect(page).to have_content(film_1.nominated)
-        expect(page).to have_content(film_2.nominated)
         expect(page).to have_content(film_3.nominated)
+        expect(page).to have_content(film_4.nominated)
       end
 
       it 'displays a link called Films Index' do

--- a/spec/features/films/show_spec.rb
+++ b/spec/features/films/show_spec.rb
@@ -50,6 +50,11 @@ RSpec.describe '/films/show.html.erb', type: :feature do
         visit "/films/#{film_3.id}"
         expect(page).to have_link("Directors Index", :href=>"/directors")
       end
+
+      it 'displays a link called update film' do
+        visit "/films/#{film_1.id}"
+        expect(page).to have_link("Update Film", :href=>"/films/#{film_1.id}/edit")
+      end
     end
 
     describe 'can click links' do
@@ -79,6 +84,12 @@ RSpec.describe '/films/show.html.erb', type: :feature do
         visit "/films/#{film_3.id}"
         click_link 'Directors Index'
         expect(page).to have_current_path("/directors")
+      end
+
+      it 'redirect the user to the film editor' do
+        visit "/films/#{film_1.id}"
+        click_link 'Update Film'
+        expect(page).to have_current_path("/films/#{film_1.id}/edit")
       end
     end
   end

--- a/spec/models/film_spec.rb
+++ b/spec/models/film_spec.rb
@@ -3,9 +3,13 @@ require 'rails_helper'
 RSpec.describe Film, type: :model do
   let!(:director_1) { Director.create!(name: 'Wes Anderson', imdb_rank: 20, tv_credit: false) }
   let!(:director_2) { Director.create!(name: 'Steven Spielberg', imdb_rank: 1, tv_credit: true) }
+  let!(:director_3) { Director.create!(name: 'George Lucas', imdb_rank: 25, tv_credit: true) }
 
   let!(:film_1) { director_1.films.create!(name: 'Bottle Rocket', rt_rank: 85, nominated: false) }
   let!(:film_2) { director_1.films.create!(name: 'Life Aquatic', rt_rank: 56, nominated: false) }
+  let!(:film_3) { director_3.films.create!(name: 'Star Wars: A New Hope', rt_rank: 92, nominated: true) }
+  let!(:film_4) { director_3.films.create!(name: 'Star Wars: Empire Strikes Back', rt_rank: 1, nominated: true) }
+
 
   describe 'validations' do
     it { should validate_presence_of(:name) }
@@ -14,5 +18,13 @@ RSpec.describe Film, type: :model do
 
   describe 'relationships' do
     it { should belong_to :director}
+  end
+
+  describe 'class methods' do
+    describe '::nominated_only' do
+      it 'can return all records that are nominated' do
+        expect(Film.nominated_only).to eq([film_3, film_4])
+      end
+    end
   end
 end


### PR DESCRIPTION
User story 16:
- Updated DirectorFilmsController#index action to accept query params from the view page link to sort all film items alphabetically.
- Added 'Sort alphabetical' link with query sort param to link to the /directors/:id/films index page.
- Created feature testing to verify sorting accuracy before and after sorting by name alphabetically.